### PR TITLE
Directory and import path setting bug

### DIFF
--- a/gofer.go
+++ b/gofer.go
@@ -77,12 +77,12 @@ var loader = template.Must(template.New("loader").Parse(`
   import (
     "os"
   )
-  
+
   // Import the gofer package.
   import(
     "github.com/chuckpreslar/gofer"
   )
-  
+
   // Imported task packages.
   import(
   {{range .Imports}}
@@ -369,7 +369,7 @@ func parsePackages(packages map[string]*ast.Package, dir string) {
 		file := ast.MergePackageFiles(pkg, ast.FilterImportDuplicates)
 
 		if isGoferTaskFile(file) {
-			imprtPath := strings.TrimLeft(strings.Replace(dir, goPath, "", 1), SourcePrefix)
+			imprtPath := strings.TrimPrefix(strings.Replace(dir, goPath, "", 1), SourcePrefix)
 			templateData.Imports = append(templateData.Imports, imprt{imprtPath})
 		}
 	}


### PR DESCRIPTION
1) Remove trailing slash suffix from GOPATH, since some users can set their GOPATH with trailing slash
2) TrimLeft deletes every consequent occurrences from dir. So if directory has `s` at the beginning, it also will remove it
